### PR TITLE
Refactor dotenv to be shared between client and server

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ yarn install
 
 #### Environment variables
 
-Create a file `packages/.env` file containing the values for the following environment variables:
+Create a file `.env` file at the root of the project containing the values for the following environment variables:
 
 ```
 TWITCH_CLIENT_ID=YOUR_CLIENT_ID

--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ yarn install
 
 #### Environment variables
 
-Create a file `packages/server/.env` file containing the values for the following environment variables:
+Create a file `packages/.env` file containing the values for the following environment variables:
 
 ```
 TWITCH_CLIENT_ID=YOUR_CLIENT_ID

--- a/packages/client/vite.config.js
+++ b/packages/client/vite.config.js
@@ -1,3 +1,5 @@
+import dotenv from "dotenv";
+dotenv.config({ path: '../.env' });
 import { defineConfig } from "vite";
 import vue from "@vitejs/plugin-vue";
 import path from "path";
@@ -10,7 +12,7 @@ export default defineConfig({
   },
   define: {
     IS_DEV: process.env.NODE_ENV !== "production",
-    APP_CLIENT_ID: JSON.stringify("fvetqbhasvewapnb7glpbqw8ic4im0"),
+    APP_CLIENT_ID: JSON.stringify(process.env.TWITCH_CLIENT_ID),
     TWITCH_OAUTH_REDIRECT_URL: JSON.stringify(
       process.env.NODE_ENV === "production" ? "https://stream-overlays-production.up.railway.app/oauth" : "http://localhost:5000/oauth"
     ),

--- a/packages/client/vite.config.js
+++ b/packages/client/vite.config.js
@@ -1,5 +1,7 @@
 import dotenv from "dotenv";
-dotenv.config({ path: '../.env' });
+
+dotenv.config({ path: path.resolve(__dirname, "../../.env") });
+
 import { defineConfig } from "vite";
 import vue from "@vitejs/plugin-vue";
 import path from "path";
@@ -13,9 +15,7 @@ export default defineConfig({
   define: {
     IS_DEV: process.env.NODE_ENV !== "production",
     APP_CLIENT_ID: JSON.stringify(process.env.TWITCH_CLIENT_ID),
-    TWITCH_OAUTH_REDIRECT_URL: JSON.stringify(
-      process.env.NODE_ENV === "production" ? "https://stream-overlays-production.up.railway.app/oauth" : "http://localhost:5000/oauth"
-    ),
+    TWITCH_OAUTH_REDIRECT_URL: JSON.stringify(process.env.TWITCH_OAUTH_REDIRECT_URL),
     __WEBSOCKET_ENDPOINT__: JSON.stringify(
       process.env.NODE_ENV === "production" ? "wss://stream-overlays-production.up.railway.app/" : "ws://localhost:3000/"
     ),

--- a/packages/server/src/apis/oauth-twitch.ts
+++ b/packages/server/src/apis/oauth-twitch.ts
@@ -29,7 +29,7 @@ async function refreshOauthTokens({ user_id, refresh_token }: { user_id: string;
         "Content-Type": "application/x-www-form-urlencoded",
       },
     })) as { data: { access_token: string; refresh_token: string; expires_in: number } };
-    console.error("Successfully refreshed user oauth tokens, updating tokens in server memory");
+    console.log("Successfully refreshed user oauth tokens, updating tokens in server memory");
     OAuthTokenMemory.setTokens(user_id, data);
     return { ...data, user_id };
   } catch (err) {

--- a/packages/server/src/index.ts
+++ b/packages/server/src/index.ts
@@ -1,4 +1,5 @@
-import "dotenv/config";
+import dotenv from "dotenv";
+dotenv.config({ path: '../../.env' });
 import express from "express";
 import { createServer } from "http";
 import cors from "cors";

--- a/packages/server/src/index.ts
+++ b/packages/server/src/index.ts
@@ -1,5 +1,6 @@
 import dotenv from "dotenv";
-dotenv.config({ path: '../../.env' });
+import path from "path";
+dotenv.config({ path: path.resolve(__dirname, "../../../.env") });
 import express from "express";
 import { createServer } from "http";
 import cors from "cors";


### PR DESCRIPTION
`APP_CLIENT_ID` was hardcoded in `vue.config.js`
It is now using a shared `.env` file.
My only doubt is if it will cause trouble with production `.env` on Railway.app, idk if each package is supposed to be independant or not.